### PR TITLE
Implement Flask-based prompt sharing site

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,17 @@
 # promptShare
-プロンプトの共有サイト
+
+Flaskベースの簡易プロンプト共有サイトです。OktaのOIDCでログインし、プロンプトを投稿したり他のユーザーが投稿したプロンプトに「いいね」やコメントを付けたりできます。データはメモリ上に保持しているため、アプリを再起動すると消えます。
+
+## 必要な環境変数
+- `OKTA_CLIENT_ID`
+- `OKTA_CLIENT_SECRET`
+- `OKTA_ISSUER` (例: `https://dev-xxxx.okta.com/oauth2/default`)
+- `FLASK_SECRET` 任意のセッション用シークレット
+
+## 起動方法
+```bash
+pip install -r requirements.txt
+python app.py
+```
+
+ブラウザで `http://localhost:5000` にアクセスしてください。

--- a/app.py
+++ b/app.py
@@ -1,0 +1,76 @@
+from flask import Flask, render_template, request, redirect, url_for, session
+from authlib.integrations.flask_client import OAuth
+import os
+
+app = Flask(__name__)
+app.secret_key = os.environ.get('FLASK_SECRET', 'supersecret')
+
+oauth = OAuth(app)
+
+def get_okta_auth():
+    okta = oauth.register(
+        name='okta',
+        client_id=os.environ.get('OKTA_CLIENT_ID'),
+        client_secret=os.environ.get('OKTA_CLIENT_SECRET'),
+        server_metadata_url=f"{os.environ.get('OKTA_ISSUER')}/.well-known/openid-configuration",
+        client_kwargs={
+            'scope': 'openid profile email'
+        }
+    )
+    return okta
+
+prompts = []
+
+@app.route('/')
+def index():
+    return render_template('index.html', prompts=prompts, user=session.get('user'))
+
+@app.route('/login')
+def login():
+    okta = get_okta_auth()
+    redirect_uri = url_for('auth', _external=True)
+    return okta.authorize_redirect(redirect_uri)
+
+@app.route('/auth')
+def auth():
+    okta = get_okta_auth()
+    token = okta.authorize_access_token()
+    user = okta.parse_id_token(token)
+    session['user'] = {
+        'name': user.get('name'),
+        'email': user.get('email')
+    }
+    return redirect('/')
+
+@app.route('/logout')
+def logout():
+    session.clear()
+    return redirect('/')
+
+@app.route('/post', methods=['POST'])
+def post_prompt():
+    content = request.form.get('content')
+    if content:
+        prompts.append({'id': len(prompts), 'content': content, 'likes': 0, 'comments': []})
+    return redirect('/')
+
+@app.route('/like/<int:pid>', methods=['POST'])
+def like_prompt(pid):
+    for p in prompts:
+        if p['id'] == pid:
+            p['likes'] += 1
+            break
+    return redirect('/')
+
+@app.route('/comment/<int:pid>', methods=['POST'])
+def comment_prompt(pid):
+    text = request.form.get('comment')
+    user = session.get('user', {}).get('name', 'Anonymous')
+    for p in prompts:
+        if p['id'] == pid and text:
+            p['comments'].append({'user': user, 'text': text})
+            break
+    return redirect('/')
+
+if __name__ == '__main__':
+    app.run(debug=True)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,2 @@
+Flask
+Authlib

--- a/templates/index.html
+++ b/templates/index.html
@@ -1,0 +1,40 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <title>Prompt Share</title>
+</head>
+<body>
+<h1>Prompt Share</h1>
+{% if user %}
+<p>Logged in as {{ user.name }} | <a href="{{ url_for('logout') }}">Logout</a></p>
+<form action="{{ url_for('post_prompt') }}" method="post">
+  <textarea name="content" rows="4" cols="50" placeholder="Write your prompt here"></textarea><br>
+  <button type="submit">Post</button>
+</form>
+{% else %}
+<p><a href="{{ url_for('login') }}">Login with Okta</a> to post</p>
+{% endif %}
+<hr>
+{% for p in prompts %}
+<div>
+  <p>{{ p.content }}</p>
+  <form action="{{ url_for('like_prompt', pid=p.id) }}" method="post" style="display:inline">
+    <button type="submit">Like ({{ p.likes }})</button>
+  </form>
+  <div>
+    <form action="{{ url_for('comment_prompt', pid=p.id) }}" method="post">
+      <input type="text" name="comment" placeholder="Add comment">
+      <button type="submit">Comment</button>
+    </form>
+  </div>
+  <ul>
+    {% for c in p.comments %}
+    <li>{{ c.user }}: {{ c.text }}</li>
+    {% endfor %}
+  </ul>
+</div>
+<hr>
+{% endfor %}
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add `app.py` with a simple Flask server and Okta OIDC authentication via authlib
- create `templates/index.html` for listing prompts, likes, and comments
- document running the app and required environment variables in `README.md`
- add `requirements.txt`

## Testing
- `python -m py_compile app.py`
- `pip install -r requirements.txt` *(fails: Tunnel connection failed)*

------
https://chatgpt.com/codex/tasks/task_b_68772980b9a8833383ff663fb0c844dc