### PR TITLE
Add prompt details and grouping

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,29 @@
 # promptShare
-プロンプトの共有サイト
+
+Flaskベースの簡易プロンプト共有サイトです。OktaのOIDCでログインし、プロンプトを投稿したり他のユーザーが投稿したプロンプトに「いいね」やコメントを付けたりできます。投稿内容はSQLiteデータベースに保存されるため、アプリを再起動しても保持されます。
+
+投稿時には以下を入力します。
+
+- プロンプト本文
+- 業務のタイプ（選択式）
+- 業務の概要
+- 得られる結果の説明
+
+投稿されたプロンプトは業務タイプごとに一覧表示され、各プロンプトの詳細ページでは概要や期待される結果、投稿者名、コメント一覧を確認できます。
+
+## 必要な環境変数
+- `OKTA_CLIENT_ID`
+- `OKTA_CLIENT_SECRET`
+- `OKTA_ISSUER` (例: `https://dev-xxxx.okta.com/oauth2/default`)
+- `FLASK_SECRET` 任意のセッション用シークレット
+- `PROMPT_DB` SQLiteのデータベースファイルパス (省略時 `prompts.db`)
+
+## 起動方法
+```bash
+pip install -r requirements.txt
+python app.py
+```
+
+初回起動時に `PROMPT_DB` で指定した場所に SQLite データベースが作成されます。
+
+ブラウザで `http://localhost:5000` にアクセスしてください。

--- a/app.py
+++ b/app.py
@@ -1,0 +1,195 @@
+from flask import Flask, render_template, request, redirect, url_for, session
+from authlib.integrations.flask_client import OAuth
+import os
+import sqlite3
+
+app = Flask(__name__)
+app.secret_key = os.environ.get('FLASK_SECRET', 'supersecret')
+
+oauth = OAuth(app)
+
+def get_okta_auth():
+    okta = oauth.register(
+        name='okta',
+        client_id=os.environ.get('OKTA_CLIENT_ID'),
+        client_secret=os.environ.get('OKTA_CLIENT_SECRET'),
+        server_metadata_url=f"{os.environ.get('OKTA_ISSUER')}/.well-known/openid-configuration",
+        client_kwargs={
+            'scope': 'openid profile email'
+        }
+    )
+    return okta
+
+
+DB_PATH = os.environ.get('PROMPT_DB', 'prompts.db')
+
+def get_db():
+    conn = sqlite3.connect(DB_PATH)
+    conn.row_factory = sqlite3.Row
+    return conn
+
+def init_db():
+    conn = get_db()
+    cur = conn.cursor()
+    cur.execute(
+        """
+        CREATE TABLE IF NOT EXISTS prompts (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            content TEXT NOT NULL,
+            work_type TEXT NOT NULL,
+            summary TEXT,
+            expected TEXT,
+            user TEXT,
+            likes INTEGER NOT NULL DEFAULT 0
+        )
+        """
+    )
+    cur.execute(
+        """
+        CREATE TABLE IF NOT EXISTS comments (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            prompt_id INTEGER NOT NULL,
+            user TEXT,
+            text TEXT,
+            FOREIGN KEY(prompt_id) REFERENCES prompts(id)
+        )
+        """
+    )
+    conn.commit()
+    conn.close()
+
+def get_prompts_grouped():
+    """Return prompts grouped by work_type."""
+    conn = get_db()
+    cur = conn.cursor()
+    cur.execute("SELECT * FROM prompts ORDER BY work_type, id DESC")
+    rows = cur.fetchall()
+    result = {}
+    for row in rows:
+        cur.execute(
+            "SELECT user, text FROM comments WHERE prompt_id=? ORDER BY id ASC",
+            (row["id"],),
+        )
+        comments = [dict(c) for c in cur.fetchall()]
+        prompt = {
+            "id": row["id"],
+            "content": row["content"],
+            "work_type": row["work_type"],
+            "summary": row["summary"],
+            "expected": row["expected"],
+            "user": row["user"],
+            "likes": row["likes"],
+            "comments": comments,
+        }
+        result.setdefault(row["work_type"], []).append(prompt)
+    conn.close()
+    return result
+
+def get_prompt(pid):
+    conn = get_db()
+    cur = conn.cursor()
+    cur.execute("SELECT * FROM prompts WHERE id=?", (pid,))
+    row = cur.fetchone()
+    if not row:
+        conn.close()
+        return None
+    cur.execute(
+        "SELECT user, text FROM comments WHERE prompt_id=? ORDER BY id ASC",
+        (pid,),
+    )
+    comments = [dict(c) for c in cur.fetchall()]
+    conn.close()
+    return {
+        "id": row["id"],
+        "content": row["content"],
+        "work_type": row["work_type"],
+        "summary": row["summary"],
+        "expected": row["expected"],
+        "user": row["user"],
+        "likes": row["likes"],
+        "comments": comments,
+    }
+
+@app.route('/')
+def index():
+    prompts = get_prompts_grouped()
+    return render_template('index.html', prompts_by_type=prompts, user=session.get('user'))
+
+
+@app.route('/prompt/<int:pid>')
+def view_prompt(pid):
+    prompt = get_prompt(pid)
+    if not prompt:
+        return redirect('/')
+    return render_template('detail.html', prompt=prompt, user=session.get('user'))
+
+@app.route('/login')
+def login():
+    okta = get_okta_auth()
+    redirect_uri = url_for('auth', _external=True)
+    return okta.authorize_redirect(redirect_uri)
+
+@app.route('/auth')
+def auth():
+    okta = get_okta_auth()
+    token = okta.authorize_access_token()
+    user = okta.parse_id_token(token)
+    session['user'] = {
+        'name': user.get('name'),
+        'email': user.get('email')
+    }
+    return redirect('/')
+
+@app.route('/logout')
+def logout():
+    session.clear()
+    return redirect('/')
+
+@app.route('/post', methods=['POST'])
+def post_prompt():
+    content = request.form.get('content')
+    work_type = request.form.get('work_type')
+    summary = request.form.get('summary')
+    expected = request.form.get('expected')
+    user = session.get('user', {}).get('name', 'Anonymous')
+    if content and work_type:
+        conn = get_db()
+        cur = conn.cursor()
+        cur.execute(
+            "INSERT INTO prompts (content, work_type, summary, expected, user, likes) VALUES (?, ?, ?, ?, ?, 0)",
+            (content, work_type, summary, expected, user),
+        )
+        conn.commit()
+        conn.close()
+    return redirect('/')
+
+@app.route('/like/<int:pid>', methods=['POST'])
+def like_prompt(pid):
+    conn = get_db()
+    cur = conn.cursor()
+    cur.execute(
+        "UPDATE prompts SET likes = likes + 1 WHERE id = ?",
+        (pid,),
+    )
+    conn.commit()
+    conn.close()
+    return redirect(request.referrer or '/')
+
+@app.route('/comment/<int:pid>', methods=['POST'])
+def comment_prompt(pid):
+    text = request.form.get('comment')
+    user = session.get('user', {}).get('name', 'Anonymous')
+    if text:
+        conn = get_db()
+        cur = conn.cursor()
+        cur.execute(
+            "INSERT INTO comments (prompt_id, user, text) VALUES (?, ?, ?)",
+            (pid, user, text),
+        )
+        conn.commit()
+        conn.close()
+    return redirect(request.referrer or '/')
+
+if __name__ == '__main__':
+    init_db()
+    app.run(debug=True)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,2 @@
+Flask
+Authlib

--- a/templates/detail.html
+++ b/templates/detail.html
@@ -1,0 +1,30 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <title>Prompt Detail</title>
+</head>
+<body>
+<h1>Prompt Detail</h1>
+<p><a href="{{ url_for('index') }}">Back</a></p>
+<div>
+  <p><strong>Prompt:</strong> {{ prompt.content }}</p>
+  <p><strong>Type:</strong> {{ prompt.work_type }}</p>
+  <p><strong>Summary:</strong> {{ prompt.summary }}</p>
+  <p><strong>Expected:</strong> {{ prompt.expected }}</p>
+  <p><strong>Posted by:</strong> {{ prompt.user }}</p>
+  <form action="{{ url_for('like_prompt', pid=prompt.id) }}" method="post" style="display:inline">
+    <button type="submit">👍 ({{ prompt.likes }})</button>
+  </form>
+  <ul>
+    {% for c in prompt.comments %}
+    <li>{{ c.user }}: {{ c.text }}</li>
+    {% endfor %}
+  </ul>
+  <form action="{{ url_for('comment_prompt', pid=prompt.id) }}" method="post">
+    <input type="text" name="comment" placeholder="Add comment">
+    <button type="submit">Comment</button>
+  </form>
+</div>
+</body>
+</html>

--- a/templates/index.html
+++ b/templates/index.html
@@ -1,0 +1,48 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <title>Prompt Share</title>
+</head>
+<body>
+<h1>Prompt Share</h1>
+{% if user %}
+<p>Logged in as {{ user.name }} | <a href="{{ url_for('logout') }}">Logout</a></p>
+<form action="{{ url_for('post_prompt') }}" method="post">
+  <textarea name="content" rows="4" cols="50" placeholder="Prompt"></textarea><br>
+  <select name="work_type">
+    <option value="writing">Writing</option>
+    <option value="research">Research</option>
+    <option value="coding">Coding</option>
+  </select><br>
+  <input type="text" name="summary" placeholder="Summary"><br>
+  <input type="text" name="expected" placeholder="Expected result"><br>
+  <button type="submit">Post</button>
+</form>
+{% else %}
+<p><a href="{{ url_for('login') }}">Login with Okta</a> to post</p>
+{% endif %}
+<hr>
+{% for work_type, plist in prompts_by_type.items() %}
+<h2>{{ work_type }}</h2>
+  {% for p in plist %}
+  <div>
+    <p><a href="{{ url_for('view_prompt', pid=p.id) }}">{{ p.content }}</a></p>
+    <form action="{{ url_for('like_prompt', pid=p.id) }}" method="post" style="display:inline">
+      <button type="submit">👍 ({{ p.likes }})</button>
+    </form>
+    <ul>
+      {% for c in p.comments %}
+      <li>{{ c.user }}: {{ c.text }}</li>
+      {% endfor %}
+    </ul>
+    <form action="{{ url_for('comment_prompt', pid=p.id) }}" method="post">
+      <input type="text" name="comment" placeholder="Add comment">
+      <button type="submit">Comment</button>
+    </form>
+  </div>
+  <hr>
+  {% endfor %}
+{% endfor %}
+</body>
+</html>


### PR DESCRIPTION
## Summary
- expand prompts table with type, summary, expected result, author
- group prompts by work type on the index page
- add detailed view page for each prompt
- show like and comment info with commenter names
- document input fields and features in README

## Testing
- `python -m py_compile app.py`
- `pip install -r requirements.txt` *(fails: Tunnel connection failed)*

------
https://chatgpt.com/codex/tasks/task_b_68772980b9a8833383ff663fb0c844dc